### PR TITLE
Always expose labels to be compatible with Opentelemetry Collector's Prometheus Receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const myCounter = Counter.with({
 ## Examples
 
 - [ts-prometheus](https://github.com/marcopacini/ts-prometheus/blob/master/example/example.ts)
-- [oak](https://github.com/marcopacini/ts-prometheus/blob/master/example/oak/main.ts)
+- [oak](https://github.com/marcopacini/ts-prometheus/blob/master/example/oak/example.ts)
 
 ## Metric Types
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ observations.
 Summary.with({
   name: "http_response_size",
   help: "A summary of the response size.",
-  quantiles: [ .25, .5, .75, 1 ]
-  maxAge: 1000 // milliseconds
-  ageBuckets: 5 // number of observations
+  quantiles: [.25, .5, .75, 1],
+  maxAge: 1000, // milliseconds
+  ageBuckets: 5, // number of observations
 });
 ```

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ http_requests_duration_count 2
 
 ### Summary
 
-By default percentiles when not set are `[ .01, .05, .9, .95, .99 ]`.
+By default quantiles when not set are `[ .01, .05, .5, .95, .99 ]`.
 
 ```ts
 let summary = Summary.with({
   name: "http_response_size",
   help: "A summary of the response size.",
-  percentiles: [.25, .5, .75, 1],
+  quantiles: [.25, .5, .75, 1],
 });
 
 let values = [1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
@@ -121,10 +121,10 @@ values.forEach((v) => summary.observe(v));
 ```
 # HELP http_response_size A summary of the response size.
 # TYPE http_response_size summary
-http_response_size{percentile="0.25"} 2
-http_response_size{percentile="0.5"} 5
-http_response_size{percentile="0.75"} 21
-http_response_size{percentile="1"} 55
+http_response_size{quantile="0.25"} 2
+http_response_size{quantile="0.5"} 5
+http_response_size{quantile="0.75"} 21
+http_response_size{quantile="1"} 55
 http_response_size_sum 143
 http_response_size_count 10
 ```
@@ -137,7 +137,7 @@ observations.
 Summary.with({
   name: "http_response_size",
   help: "A summary of the response size.",
-  percentiles: [ .25, .5, .75, 1 ]
+  quantiles: [ .25, .5, .75, 1 ]
   maxAge: 1000 // milliseconds
   ageBuckets: 5 // number of observations
 });

--- a/example/example.ts
+++ b/example/example.ts
@@ -46,7 +46,7 @@ histogram.observe(.58);
 const summary = Summary.with({
   name: "http_response_size",
   help: "A summary of the response size.",
-  percentiles: [.25, .5, .75, 1],
+  quantiles: [.25, .5, .75, 1],
 });
 
 const values = [1, 1, 2, 3, 5, 8, 13, 21, 34, 55];

--- a/example/oak/example.ts
+++ b/example/oak/example.ts
@@ -28,7 +28,7 @@ app.use(async (ctx, next) => {
   counter.labels({
     path: ctx.request.url.pathname,
     method: ctx.request.method,
-    status: ctx.response.status || "",
+    status: String(ctx.response.status || 200),
   }).inc();
 });
 

--- a/histogram.ts
+++ b/histogram.ts
@@ -59,8 +59,10 @@ export class Histogram extends Metric implements Observe {
       labels = labels.replace("Infinity", "+Inf");
       text += `${this.collector.name}_bucket${labels} ${this.values[i]}\n`;
     }
-    text += `${this.collector.name}_sum ${this.sum}\n`;
-    text += `${this.collector.name}_count ${this.count}`;
+
+    const labels = this.getLabelsAsString();
+    text += `${this.collector.name}_sum${labels} ${this.sum}\n`;
+    text += `${this.collector.name}_count${labels} ${this.count}`;
     return text;
   }
 

--- a/histogram.ts
+++ b/histogram.ts
@@ -24,9 +24,11 @@ export class Histogram extends Metric implements Observe {
       "histogram",
       config.registry,
     );
+
     const labels = config.labels || [];
     const buckets = config.buckets || [];
     buckets.push(Infinity);
+
     return new Histogram(collector, labels, buckets);
   }
 
@@ -53,7 +55,9 @@ export class Histogram extends Metric implements Observe {
     if (this.count == 0) {
       return undefined;
     }
+
     let text = "";
+
     for (let i = 0; i < this.buckets.length; i++) {
       let labels = this.getLabelsAsString({ le: `${this.buckets[i]}` });
       labels = labels.replace("Infinity", "+Inf");
@@ -68,6 +72,7 @@ export class Histogram extends Metric implements Observe {
 
   labels(labels: Labels): Observe {
     let child = new Histogram(this.collector, this.labelNames, this.buckets);
+
     for (const key of Object.keys(labels)) {
       const index = child.labelNames.indexOf(key);
       if (index === -1) {
@@ -75,6 +80,7 @@ export class Histogram extends Metric implements Observe {
       }
       child.labelValues[index] = labels[key];
     }
+
     child = child.collector.getOrSetMetric(child) as Histogram;
 
     return {
@@ -86,9 +92,11 @@ export class Histogram extends Metric implements Observe {
 
   observe(n: number) {
     const index = this.buckets.findIndex((v) => v >= n);
+
     for (let i = index; i < this.values.length; i++) {
       this.values[i] += 1;
     }
+
     this.sum += n;
     this.count += 1;
   }

--- a/histogram_test.ts
+++ b/histogram_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows, test } from "./test_deps.ts";
 
+import { Registry } from "./registry.ts";
 import { Histogram } from "./histogram.ts";
 
 test({
@@ -20,5 +21,47 @@ test({
         buckets: [],
       });
     });
+  },
+});
+
+// Reference: https://github.com/open-telemetry/opentelemetry-go/blob/d5fca833d6f6fc75e092c2108e0265aa778b8923/exporters/prometheus/testdata/histogram.txt
+//       and: https://github.com/open-telemetry/opentelemetry-go/blob/d5fca833d6f6fc75e092c2108e0265aa778b8923/exporters/prometheus/exporter_test.go#L93-L112
+
+const histogramTxt = `
+# HELP histogram_baz_bytes a very nice histogram
+# TYPE histogram_baz_bytes histogram
+histogram_baz_bytes_bucket{A="B",C="D",le="0"} 0
+histogram_baz_bytes_bucket{A="B",C="D",le="5"} 0
+histogram_baz_bytes_bucket{A="B",C="D",le="10"} 1
+histogram_baz_bytes_bucket{A="B",C="D",le="25"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="50"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="75"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="100"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="250"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="500"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="1000"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="+Inf"} 4
+histogram_baz_bytes_sum{A="B",C="D"} 236
+histogram_baz_bytes_count{A="B",C="D"} 4
+`.trimStart();
+
+test({
+  name: "Histogram with labels outputs the correct format for prometheus",
+  fn() {
+    const histogram = Histogram.with({
+      name: "histogram_baz_bytes",
+      help: "a very nice histogram",
+      buckets: [0, 5, 10, 25, 50, 75, 100, 250, 500, 1000],
+      labels: ["A", "C"],
+    });
+
+    const labels = { A: "B", C: "D" };
+
+    histogram.labels(labels).observe(23);
+    histogram.labels(labels).observe(7);
+    histogram.labels(labels).observe(101);
+    histogram.labels(labels).observe(105);
+
+    assertEquals(Registry.default.metrics(), histogramTxt);
   },
 });

--- a/histogram_test.ts
+++ b/histogram_test.ts
@@ -1,5 +1,4 @@
 import { assertEquals, assertThrows, test } from "./test_deps.ts";
-
 import { Registry } from "./registry.ts";
 import { Histogram } from "./histogram.ts";
 

--- a/summary.ts
+++ b/summary.ts
@@ -22,7 +22,7 @@ class Sample {
 
 export class Summary extends Metric implements Observe {
   private collector: Collector;
-  private percentiles: number[];
+  private quantiles: number[];
   private values: Sample[];
   private maxAge?: number;
   private ageBuckets?: number;
@@ -32,7 +32,7 @@ export class Summary extends Metric implements Observe {
       name: string;
       help: string;
       labels?: string[];
-      percentiles?: number[];
+      quantiles?: number[];
       maxAge?: number;
       ageBuckets?: number;
       registry?: Registry[];
@@ -44,17 +44,14 @@ export class Summary extends Metric implements Observe {
       "summary",
       config.registry,
     );
+
     const labels = config.labels || [];
-    const percentiles = config.percentiles || [.01, .05, .9, .95, .99];
-    percentiles.forEach((v) => {
-      if (v < 0 || v > 1) {
-        throw new Error(`invalid percentile: ${v} not in [0,1]`);
-      }
-    });
+    const quantiles = config.quantiles || [.01, .05, .5, .95, .99];
+
     return new Summary(
       collector,
       labels,
-      percentiles,
+      quantiles,
       config.maxAge,
       config.ageBuckets,
     );
@@ -63,17 +60,23 @@ export class Summary extends Metric implements Observe {
   private constructor(
     collector: Collector,
     labels: string[],
-    percentiles: number[],
+    quantiles: number[],
     maxAge?: number,
     ageBuckets?: number,
   ) {
     super(labels, new Array(labels.length).fill(undefined));
     this.collector = collector;
-    this.percentiles = percentiles.sort((a, b) => a < b ? -1 : 1);
+    this.quantiles = quantiles.sort((a, b) => a < b ? -1 : 1);
     this.values = [];
     this.maxAge = maxAge;
     this.ageBuckets = ageBuckets;
     this.collector.getOrSetMetric(this);
+
+    quantiles.forEach((v) => {
+      if (v < 0 || v > 1) {
+        throw new Error(`invalid quantiles: ${v} not in [0,1]`);
+      }
+    });
   }
 
   get description(): string {
@@ -94,6 +97,7 @@ export class Summary extends Metric implements Observe {
       }
       this.values = this.values.slice(i);
     }
+
     // Remove extra values
     if (this.ageBuckets !== undefined) {
       const index = this.values.length - this.ageBuckets;
@@ -111,7 +115,7 @@ export class Summary extends Metric implements Observe {
     this.clean();
     const sorted = this.values.slice().sort((a, b) => a.getValue() - b.getValue());
 
-    for (const p of this.percentiles) {
+    for (const p of this.quantiles) {
       const labels = this.getLabelsAsString({ quantile: p.toString() });
       let index = Math.ceil(p * sorted.length);
       index = index == 0 ? 0 : index - 1;
@@ -128,7 +132,8 @@ export class Summary extends Metric implements Observe {
   }
 
   labels(labels: Labels): Observe {
-    let child = new Summary(this.collector, this.labelNames, this.percentiles);
+    let child = new Summary(this.collector, this.labelNames, this.quantiles);
+
     for (const key of Object.keys(labels)) {
       const index = child.labelNames.indexOf(key);
       if (index === -1) {
@@ -136,6 +141,7 @@ export class Summary extends Metric implements Observe {
       }
       child.labelValues[index] = labels[key];
     }
+
     child = child.collector.getOrSetMetric(child) as Summary;
 
     return {

--- a/summary.ts
+++ b/summary.ts
@@ -109,12 +109,10 @@ export class Summary extends Metric implements Observe {
     let text = "";
 
     this.clean();
-    const sorted = this.values.slice().sort((a, b) =>
-      a.getValue() - b.getValue()
-    );
+    const sorted = this.values.slice().sort((a, b) => a.getValue() - b.getValue());
 
     for (const p of this.percentiles) {
-      const labels = this.getLabelsAsString({ percentile: p.toString() });
+      const labels = this.getLabelsAsString({ quantile: p.toString() });
       let index = Math.ceil(p * sorted.length);
       index = index == 0 ? 0 : index - 1;
       const value = sorted[index].getValue();

--- a/summary.ts
+++ b/summary.ts
@@ -113,7 +113,9 @@ export class Summary extends Metric implements Observe {
     let text = "";
 
     this.clean();
-    const sorted = this.values.slice().sort((a, b) => a.getValue() - b.getValue());
+    const sorted = this.values.slice().sort((a, b) =>
+      a.getValue() - b.getValue()
+    );
 
     for (const p of this.quantiles) {
       const labels = this.getLabelsAsString({ quantile: p.toString() });

--- a/summary.ts
+++ b/summary.ts
@@ -121,9 +121,10 @@ export class Summary extends Metric implements Observe {
       text += `${this.collector.name}${labels} ${value}\n`;
     }
 
+    const labels = this.getLabelsAsString();
     const sum = this.values.reduce((sum, v) => sum + v.getValue(), 0);
-    text += `${this.collector.name}_sum ${sum}\n`;
-    text += `${this.collector.name}_count ${sorted.length}`;
+    text += `${this.collector.name}_sum${labels} ${sum}\n`;
+    text += `${this.collector.name}_count${labels} ${sorted.length}`;
 
     return text;
   }

--- a/summary_test.ts
+++ b/summary_test.ts
@@ -1,7 +1,4 @@
-import { assertEquals, assertThrows, test } from "./test_deps.ts";
-
-import { delay } from "https://deno.land/std/async/delay.ts";
-
+import { assertEquals, assertThrows, delay, test } from "./test_deps.ts";
 import { Summary } from "./summary.ts";
 import { Registry } from "./registry.ts";
 
@@ -9,7 +6,7 @@ test({
   name: "Summary.with",
   fn() {
     const summary = Summary.with({
-      name: "summary_withouts_labels_and_percentiles",
+      name: "summary_withouts_labels_and_quantiles",
       help: "help",
     });
 
@@ -17,7 +14,7 @@ test({
 
     assertThrows(() => {
       Summary.with({
-        name: "summary_withouts_labels_and_percentiles",
+        name: "summary_withouts_labels_and_quantiles",
         help: "help",
       });
     });
@@ -28,7 +25,7 @@ test({
   name: "Summary.observe",
   fn() {
     const summary = Summary.with({
-      name: "summary_withouts_labels_and_percentiles",
+      name: "summary_withouts_labels_and_quantiles",
       help: "help",
       registry: [new Registry()],
     });
@@ -55,7 +52,7 @@ test({
   name: "Summary.observe (maxAge)",
   async fn() {
     const summary = Summary.with({
-      name: "summary_withouts_labels_and_percentiles",
+      name: "summary_withouts_labels_and_quantiles",
       help: "help",
       maxAge: 3000, // ms
       registry: [new Registry()],
@@ -86,7 +83,7 @@ test({
   name: "Summary.observe (ageBuckets)",
   fn() {
     const summary = Summary.with({
-      name: "summary_withouts_labels_and_percentiles",
+      name: "summary_withouts_labels_and_quantiles",
       help: "help",
       ageBuckets: 3,
       registry: [new Registry()],
@@ -112,7 +109,7 @@ const histogramTxt = `
 # TYPE summary_baz_bytes summary
 summary_baz_bytes{A="B",C="D",quantile="0.01"} 2
 summary_baz_bytes{A="B",C="D",quantile="0.05"} 2
-summary_baz_bytes{A="B",C="D",quantile="0.9"} 105
+summary_baz_bytes{A="B",C="D",quantile="0.5"} 5
 summary_baz_bytes{A="B",C="D",quantile="0.95"} 105
 summary_baz_bytes{A="B",C="D",quantile="0.99"} 105
 summary_baz_bytes_sum{A="B",C="D"} 250

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -13,6 +13,8 @@ export {
   runBenchmarks,
 } from "https://deno.land/std@0.106.0/testing/bench.ts";
 
+export { delay } from "https://deno.land/std@0.106.0/async/delay.ts";
+
 export class MetricMock extends Metric {
   constructor(labelNames: string[] = [], labelValues: string[] = []) {
     super(labelNames, labelValues);


### PR DESCRIPTION
The Opentelemetry Collector's Prometheus Receiver expects labels to be sent with every line of a metric, not just the buckets / quantiles. It also expect quantiles to be between 0 and 1, and percentiles to be between 0 and 100, so I've adjusted everything to quantiles.

Also: default quantiles now include the median.