### PR TITLE
add config for deno fmt to pass github ci runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+.vscode

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,11 @@
+{
+  "fmt": {
+    "options": {
+      "useTabs": false,
+      "lineWidth": 80,
+      "indentWidth": 2,
+      "singleQuote": false,
+      "proseWrap": "preserve"
+    }
+  }
+}

--- a/example/hono/example.ts
+++ b/example/hono/example.ts
@@ -1,37 +1,34 @@
-import { serve } from 'https://deno.land/std@0.175.0/http/server.ts';
-import { Context, Hono } from 'https://deno.land/x/hono/mod.ts';
-import {
-  Counter,
-  Registry
-} from 'https://deno.land/x/ts_prometheus/mod.ts';
+import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
+import { Context, Hono } from "https://deno.land/x/hono/mod.ts";
+import { Counter, Registry } from "https://deno.land/x/ts_prometheus/mod.ts";
 
 const app = new Hono();
 
 const counter = Counter.with({
-  name: 'http_requests_total',
-  help: 'The total HTTP requests',
-  labels: ['path', 'method', 'status'],
+  name: "http_requests_total",
+  help: "The total HTTP requests",
+  labels: ["path", "method", "status"],
 });
 
 // Metrics endpoint
-app.get('/metrics', (c: Context): Response => {
-  c.set('Content-Type', 'text/plain; version=0.0.4');
+app.get("/metrics", (c: Context): Response => {
+  c.set("Content-Type", "text/plain; version=0.0.4");
   return c.text(Registry.default.metrics(), 200);
 });
 
 // Routes following the middleware will be measured
-app.use('*', async (c: Context, next): Promise<void> => {
+app.use("*", async (c: Context, next): Promise<void> => {
   await next();
   counter.labels({
     path: new URL(c.req.url).pathname,
     method: c.req.method,
-    status: c.res.status.toString() || '',
+    status: c.res.status.toString() || "",
   }).inc();
 });
 
 // Hello World route
-app.get('/', (c): Response => {
-  return c.text('Hello World', 200);
+app.get("/", (c): Response => {
+  return c.text("Hello World", 200);
 });
 
 serve(app.fetch);


### PR DESCRIPTION
GitHub CI/CD doesn't pass automated deno fmt --check due to missing configuration for quotes. It always checks for single quotes and fails due to existing double quotes.